### PR TITLE
Add API endpoints for joke, weather, and recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # skillsettest
+
+## Instructions to run the script
+
+1. Make sure you have Python installed on your system.
+2. Install the `requests` library if you haven't already by running `pip install requests`.
+3. Save the `main.py` file in your working directory.
+4. Open a terminal or command prompt and navigate to the directory where `main.py` is saved.
+5. Run the script by executing `python main.py`.
+6. The script will print a random joke, today's weather, and a random recipe.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+import requests
+
+def get_joke():
+    response = requests.get("https://official-joke-api.appspot.com/random_joke")
+    if response.status_code == 200:
+        joke = response.json()
+        return f"{joke['setup']} - {joke['punchline']}"
+    else:
+        return "Failed to fetch a joke."
+
+def get_weather():
+    api_key = "your_api_key"
+    city = "your_city"
+    response = requests.get(f"http://api.openweathermap.org/data/2.5/weather?q={city}&appid={api_key}")
+    if response.status_code == 200:
+        weather = response.json()
+        return f"Weather in {city}: {weather['weather'][0]['description']}, Temperature: {weather['main']['temp']}K"
+    else:
+        return "Failed to fetch weather."
+
+def get_recipe():
+    response = requests.get("https://www.themealdb.com/api/json/v1/1/random.php")
+    if response.status_code == 200:
+        recipe = response.json()
+        return f"Recipe: {recipe['meals'][0]['strMeal']}, Instructions: {recipe['meals'][0]['strInstructions']}"
+    else:
+        return "Failed to fetch a recipe."
+
+def main():
+    print(get_joke())
+    print(get_weather())
+    print(get_recipe())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add functionality to hit 3 random endpoints for telling a joke, getting today's weather, and a recipe.

* **main.py**
  - Import the `requests` module to make HTTP requests.
  - Define a function `get_joke()` to fetch a random joke from an API.
  - Define a function `get_weather()` to fetch today's weather from an API.
  - Define a function `get_recipe()` to fetch a random recipe from an API.
  - Define a `main()` function to call the API functions and print the results.

* **README.md**
  - Add instructions on how to run the `main.py` script.
  - Include steps to install the `requests` library and execute the script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sneha-natekar/skillsettest/pull/1?shareId=ee6276d7-32ee-40da-bc79-38b1a9ac3d45).